### PR TITLE
wrap pyaircontrol.py path in double quotes

### DIFF
--- a/src/accessories/accessories.handler.js
+++ b/src/accessories/accessories.handler.js
@@ -16,7 +16,7 @@ class Handler {
 
     this.args = [
       'python3',
-      `${path.resolve(__dirname, '../../')}/lib/pyaircontrol.py`,
+      `"${path.resolve(__dirname, '../../')}/lib/pyaircontrol.py"`,
       '-H',
       this.accessory.context.config.host,
       '-P',


### PR DESCRIPTION
Fix issues when path contains folder with space in it